### PR TITLE
Add support for MaxMind GeoIP2 module

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -34,6 +34,7 @@ The following table shows a configuration option's name, type, and the default v
 |[error-log-path](#error-log-path)|string|"/var/log/nginx/error.log"|
 |[enable-dynamic-tls-records](#enable-dynamic-tls-records)|bool|"true"|
 |[enable-modsecurity](#enable-modsecurity)|bool|"false"|
+|[enable-geoip2](#enable-geoip2)|bool|"false"|
 |[enable-owasp-modsecurity-crs](#enable-owasp-modsecurity-crs)|bool|"false"|
 |[client-header-buffer-size](#client-header-buffer-size)|string|"1k"|
 |[client-header-timeout](#client-header-timeout)|int|60|
@@ -182,6 +183,13 @@ _References:_
 ## enable-modsecurity
 
 Enables the modsecurity module for NGINX. _**default:**_ is disabled
+
+## enable-geoip2
+
+Enables the geoip2 module for NGINX. By default this is disabled.
+
+_References:_
+- https://github.com/leev/ngx_http_geoip2_module
 
 ## enable-owasp-modsecurity-crs
 
@@ -539,7 +547,7 @@ The value can either be:
 - round_robin: to use the default round robin loadbalancer
 - least_conn: to use the least connected method
 - ip_hash: to use a hash of the server for routing.
-- ewma: to use the peak ewma method for routing (only available with `enable-dynamic-configuration` flag) 
+- ewma: to use the peak ewma method for routing (only available with `enable-dynamic-configuration` flag)
 
 The default is least_conn.
 

--- a/images/nginx/build.sh
+++ b/images/nginx/build.sh
@@ -35,6 +35,7 @@ export MODSECURITY_VERSION=1.0.0
 export LUA_NGX_VERSION=0.10.12rc2
 export LUA_UPSTREAM_VERSION=0.07
 export COOKIE_FLAG_VERSION=1.1.0
+export GEOIP2_VERSION=2.0
 
 export BUILD_PATH=/tmp/build
 
@@ -87,6 +88,7 @@ clean-install \
   lua-cjson \
   python \
   luarocks \
+  libmaxminddb-dev \
   || exit 1
 
 ln -s /usr/lib/x86_64-linux-gnu/liblua5.1.so /usr/lib/liblua.so
@@ -109,6 +111,8 @@ function geoip_get {
 geoip_get "GeoIP.dat.gz" "https://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz"
 geoip_get "GeoLiteCity.dat.gz" "https://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz"
 geoip_get "GeoIPASNum.dat.gz" "http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz"
+geoip_get "GeoLite2-City.mmdb.gz" "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz"
+geoip_get "GeoLite2-ASN.mmdb.gz" "http://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz"
 
 mkdir --verbose -p "$BUILD_PATH"
 cd "$BUILD_PATH"
@@ -192,6 +196,8 @@ get_src d81b33129c6fb5203b571fa4d8394823bf473d8872c0357a1d0f14420b1483bd \
 get_src 1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3 \
         "http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz"
 
+get_src ebb4652c4f9a2e1ee31fddefc4c93ff78e651a4b2727d3453d026bccbd708d99 \
+        "https://github.com/leev/ngx_http_geoip2_module/archive/${GEOIP2_VERSION}.tar.gz"
 
 # improve compilation times
 CORES=$(($(grep -c ^processor /proc/cpuinfo) - 0))
@@ -390,6 +396,7 @@ WITH_MODULES="--add-module=$BUILD_PATH/ngx_devel_kit-$NDK_VERSION \
   --add-dynamic-module=$BUILD_PATH/nginx-opentracing-$NGINX_OPENTRACING_VERSION/jaeger \
   --add-dynamic-module=$BUILD_PATH/nginx-opentracing-$NGINX_OPENTRACING_VERSION/zipkin \
   --add-dynamic-module=$BUILD_PATH/ModSecurity-nginx-$MODSECURITY_VERSION \
+  --add-dynamic-module=$BUILD_PATH/ngx_http_geoip2_module-${GEOIP2_VERSION} \
   --add-module=$BUILD_PATH/ngx_brotli"
 
 ./configure \

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -119,6 +119,10 @@ type Configuration struct {
 	// By default this is disabled
 	EnableModsecurity bool `json:"enable-modsecurity"`
 
+	// EnableGeoIp2 enables the geoip2 module for NGINX
+	// By default this is disabled
+	EnableGeoIp2 bool `json:"enable-geoip2"`
+
 	// EnableModsecurity enables the OWASP ModSecurity Core Rule Set (CRS)
 	// By default this is disabled
 	EnableOWASPCoreRules bool `json:"enable-owasp-modsecurity-crs"`

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -11,6 +11,10 @@
 load_module /etc/nginx/modules/ngx_http_modsecurity_module.so;
 {{ end }}
 
+{{ if $cfg.EnableGeoIp2 }}
+load_module /etc/nginx/modules/ngx_http_geoip2_module.so;
+{{ end }}
+
 {{ buildOpentracingLoad $cfg }}
 
 daemon off;
@@ -95,6 +99,26 @@ http {
     geoip_city          /etc/nginx/geoip/GeoLiteCity.dat;
     geoip_org           /etc/nginx/geoip/GeoIPASNum.dat;
     geoip_proxy_recursive on;
+    {{ end }}
+
+    {{ if $cfg.EnableGeoIp2 }}
+	# https://github.com/section-io/ngx_http_geoip2_module#example-usage
+	geoip2 /etc/nginx/geoip/GeoLite2-City.mmdb {
+		# use `mmdblookup` to see the available fields
+		$geoip2_city_country_code source=$the_real_ip country iso_code;
+		$geoip2_city_country_name country names en;
+		$geoip2_city city names en;
+		$geoip2_postal_code postal code;
+		$geoip2_dma_code location metro_code;
+		$geoip2_latitude location latitude;
+		$geoip2_longitude location longitude;
+		$geoip2_region_code subdivisions 0 iso_code;
+		$geoip2_region_name subdivisions 0 names en;
+	}
+
+	geoip2 /etc/nginx/geoip/GeoLite2-ASN.mmdb {
+		$geoip2_asn source=$the_real_ip autonomous_system_number;
+	}
     {{ end }}
 
     {{ if $cfg.EnableVtsStatus }}


### PR DESCRIPTION
MaxMind is deprecating their legacy databases, updates for them will no longer be available after 2019-01-02.  See https://support.maxmind.com/geolite-legacy-discontinuation-notice/

This adds support for the GeoLite2 databases https://dev.maxmind.com/geoip/geoip2/geolite2/ via https://github.com/leev/ngx_http_geoip2_module.