### PR TITLE
increasing the size of configuration and certificate dictionaries to …

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -212,8 +212,8 @@ func buildLuaSharedDictionaries(s interface{}, disableLuaRestyWAF bool) string {
 	}
 
 	out := []string{
-		"lua_shared_dict configuration_data 5M",
-		"lua_shared_dict certificate_data 16M",
+		"lua_shared_dict configuration_data 50M",
+		"lua_shared_dict certificate_data 50M",
 	}
 
 	if !disableLuaRestyWAF {


### PR DESCRIPTION
…accomodate large numbers of domains, over 5k

I've built and tested this locally using the ingress-test suite in delivery.kubernetes
