### PR TITLE
sorting by namespace when ingresses have matching creationtimestamps

### DIFF
--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -770,6 +770,9 @@ func (s *k8sStore) ListIngresses() []*ingress.Ingress {
 	sort.SliceStable(ingresses, func(i, j int) bool {
 		ir := ingresses[i].CreationTimestamp
 		jr := ingresses[j].CreationTimestamp
+		if ir == jr {
+			return ingresses[i].Namespace < ingresses[j].Namespace
+		}
 		return ir.Before(&jr)
 	})
 


### PR DESCRIPTION
The CreationTimestamp field only has a resolution at the minute level, so ingresses created in the same minute have the same timestamp and can be sorted inconsistently, leading to reloads that are unneeded. Adding namespace helps make it consistent, at least for our use case.