### PR TITLE
adding  to proxy_pass for rewrites so that url encoding is maintained…

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -510,7 +510,7 @@ func buildProxyPass(host string, b interface{}, loc interface{}) string {
 
 		return fmt.Sprintf(`
 rewrite "(?i)%s" %s break;
-%v%v %s%s;`, path, location.Rewrite.Target, xForwardedPrefix, proxyPass, proto, upstreamName)
+%v%v %s%s$uri;`, path, location.Rewrite.Target, xForwardedPrefix, proxyPass, proto, upstreamName)
 	}
 
 	// default proxy_pass

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -509,7 +509,9 @@ func buildProxyPass(host string, b interface{}, loc interface{}) string {
 		}
 
 		return fmt.Sprintf(`
+rewrite ^ $request_uri;
 rewrite "(?i)%s" %s break;
+return 400;
 %v%v %s%s$uri;`, path, location.Rewrite.Target, xForwardedPrefix, proxyPass, proto, upstreamName)
 	}
 


### PR DESCRIPTION
Based on info from here https://stackoverflow.com/questions/28995818/nginx-proxy-pass-and-url-decoding/37584656

This keeps url encoding particularly for characters like "/" (%2F) from being parsed instead of passed through