### PR TITLE
Expose LUA configuration & certificate dictionary metrics

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -248,6 +248,14 @@ func buildLuaSharedDictionaries(c interface{}, s interface{}, disableLuaRestyWAF
 		klog.Errorf("expected an '[]*ingress.Server' type but %T was returned", s)
 		return ""
 	}
+
+	// check if config contains lua "lua_metrics_data" value otherwise, use default
+	metricsData, ok := cfg.LuaSharedDicts["metrics_data"]
+	if !ok {
+		metricsData = 32
+	}
+	out = append(out, fmt.Sprintf("lua_shared_dict metrics_data %dk", metricsData))
+
 	// check if config contains lua "lua_configuration_data" value otherwise, use default
 	cfgData, ok := cfg.LuaSharedDicts["configuration_data"]
 	if !ok {

--- a/internal/ingress/metric/collectors/nginx_lua_status.go
+++ b/internal/ingress/metric/collectors/nginx_lua_status.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/ingress-nginx/internal/nginx"
+	"k8s.io/klog"
+)
+
+var (
+	reCertCapacityBytes  = regexp.MustCompile(`cert_capacity_bytes: (\d+)`)
+	reCertFreeSpaceBytes = regexp.MustCompile(`cert_free_space_bytes: (\d+)`)
+	reCertLastFail       = regexp.MustCompile(`cert_last_fail: (\d+)`)
+	reCertLastForcible   = regexp.MustCompile(`cert_last_forcible: (\d+)`)
+	reCertLastSuccess    = regexp.MustCompile(`cert_last_success: (\d+)`)
+	reCertOverflowTotal  = regexp.MustCompile(`cert_overflow_total: (\d+)`)
+	reConfCapacityBytes  = regexp.MustCompile(`conf_capacity_bytes: (\d+)`)
+	reConfFreeSpaceBytes = regexp.MustCompile(`conf_free_space_bytes: (\d+)`)
+)
+
+type (
+	nginxLuaStatusCollector struct {
+		scrapeChan chan scrapeRequest
+
+		data *nginxLuaStatusData
+	}
+
+	nginxLuaStatusData struct {
+		certificateLast          *prometheus.Desc
+		certificateOverflowTotal *prometheus.Desc
+		sharedDictionaryCapacity *prometheus.Desc
+		sharedDictionaryFree     *prometheus.Desc
+	}
+
+	basicLuaStatus struct {
+		CertificateCapacity      int
+		CertificateFreeSpace     int
+		CertificateLastFail      int
+		CertificateLastForcible  int
+		CertificateLastSuccess   int
+		CertificateOverflowTotal int
+		ConfigurationCapacity    int
+		ConfigurationFreeSpace   int
+	}
+)
+
+// NGINXLuaStatusCollector defines a LUA status collector interface
+type NGINXLuaStatusCollector interface {
+	prometheus.Collector
+
+	Start()
+	Stop()
+}
+
+// NewNGINXLuaStatus returns a new prometheus collector for the dynamic configuration+certificate LUA
+func NewNGINXLuaStatus(podName, namespace, ingressClass string) (NGINXLuaStatusCollector, error) {
+	p := nginxLuaStatusCollector{
+		scrapeChan: make(chan scrapeRequest),
+	}
+
+	constLabels := prometheus.Labels{
+		"controller_namespace": namespace,
+		"controller_class":     ingressClass,
+		"controller_pod":       podName,
+	}
+
+	p.data = &nginxLuaStatusData{
+		certificateLast: prometheus.NewDesc(
+			prometheus.BuildFQName(PrometheusNamespace, subSystem, "cert_count"),
+			"number of certs in last configuration update state {success, forcible, fail}",
+			[]string{"result"}, constLabels),
+
+		certificateOverflowTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(PrometheusNamespace, subSystem, "cert_overflow_total"),
+			"number of valid items removed forcibly when out of storage in the shared memory zone",
+			nil, constLabels),
+
+		sharedDictionaryCapacity: prometheus.NewDesc(
+			prometheus.BuildFQName(PrometheusNamespace, subSystem, "dictionary_capacity"),
+			"capacity in bytes for the shm-based dictionary",
+			[]string{"name"}, constLabels),
+
+		sharedDictionaryFree: prometheus.NewDesc(
+			prometheus.BuildFQName(PrometheusNamespace, subSystem, "dictionary_free"),
+			"free page size in bytes for the shm-based dictionary",
+			[]string{"name"}, constLabels),
+	}
+
+	return p, nil
+}
+
+// Describe implements prometheus.Collector.
+func (p nginxLuaStatusCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- p.data.certificateLast
+	ch <- p.data.certificateOverflowTotal
+	ch <- p.data.sharedDictionaryCapacity
+	ch <- p.data.sharedDictionaryFree
+}
+
+// Collect implements prometheus.Collector.
+func (p nginxLuaStatusCollector) Collect(ch chan<- prometheus.Metric) {
+	req := scrapeRequest{results: ch, done: make(chan struct{})}
+	p.scrapeChan <- req
+	<-req.done
+}
+
+func (p nginxLuaStatusCollector) Start() {
+	for req := range p.scrapeChan {
+		ch := req.results
+		p.scrape(ch)
+		req.done <- struct{}{}
+	}
+}
+
+func (p nginxLuaStatusCollector) Stop() {
+	close(p.scrapeChan)
+}
+
+func parseLua(data string) *basicLuaStatus {
+	return &basicLuaStatus{
+		CertificateCapacity:      toInt(reCertCapacityBytes.FindStringSubmatch(data), 1),
+		CertificateFreeSpace:     toInt(reCertFreeSpaceBytes.FindStringSubmatch(data), 1),
+		CertificateLastFail:      toInt(reCertLastFail.FindStringSubmatch(data), 1),
+		CertificateLastForcible:  toInt(reCertLastForcible.FindStringSubmatch(data), 1),
+		CertificateLastSuccess:   toInt(reCertLastSuccess.FindStringSubmatch(data), 1),
+		CertificateOverflowTotal: toInt(reCertOverflowTotal.FindStringSubmatch(data), 1),
+		ConfigurationCapacity:    toInt(reConfCapacityBytes.FindStringSubmatch(data), 1),
+		ConfigurationFreeSpace:   toInt(reConfFreeSpaceBytes.FindStringSubmatch(data), 1),
+	}
+}
+
+// nginxStatusCollector scrape the nginx status
+func (p nginxLuaStatusCollector) scrape(ch chan<- prometheus.Metric) {
+	klog.V(3).Infof("start scraping socket: %v", nginx.LuaStatusPath)
+	status, data, err := nginx.NewGetStatusRequest(nginx.LuaStatusPath)
+	if err != nil {
+		log.Printf("%v", err)
+		klog.Warningf("unexpected error obtaining nginx lua status info: %v", err)
+		return
+	}
+
+	if status < 200 || status >= 400 {
+		klog.Warningf("unexpected error obtaining nginx lua status info (status %v)", status)
+		return
+	}
+
+	s := parseLua(string(data))
+
+	ch <- prometheus.MustNewConstMetric(p.data.certificateLast, prometheus.GaugeValue, float64(s.CertificateLastFail), "fail")
+	ch <- prometheus.MustNewConstMetric(p.data.certificateLast, prometheus.GaugeValue, float64(s.CertificateLastForcible), "forcible")
+	ch <- prometheus.MustNewConstMetric(p.data.certificateLast, prometheus.GaugeValue, float64(s.CertificateLastSuccess), "success")
+	ch <- prometheus.MustNewConstMetric(p.data.certificateOverflowTotal, prometheus.CounterValue, float64(s.CertificateOverflowTotal))
+	ch <- prometheus.MustNewConstMetric(p.data.sharedDictionaryCapacity, prometheus.GaugeValue, float64(s.CertificateCapacity), "certificate")
+	ch <- prometheus.MustNewConstMetric(p.data.sharedDictionaryCapacity, prometheus.GaugeValue, float64(s.ConfigurationCapacity), "configuration")
+	ch <- prometheus.MustNewConstMetric(p.data.sharedDictionaryFree, prometheus.GaugeValue, float64(s.CertificateFreeSpace), "certificate")
+	ch <- prometheus.MustNewConstMetric(p.data.sharedDictionaryFree, prometheus.GaugeValue, float64(s.ConfigurationFreeSpace), "configuration")
+}

--- a/internal/ingress/metric/collectors/nginx_lua_status_test.go
+++ b/internal/ingress/metric/collectors/nginx_lua_status_test.go
@@ -37,29 +37,15 @@ func TestLuaStatusCollector(t *testing.T) {
 		want    string
 	}{
 		{
-			name: "should return empty zero metrics",
+			name: "should return empty or zero metrics",
 			mock: `
 			`,
 			want: `
-				# HELP nginx_ingress_controller_nginx_process_cert_count number of certs in last configuration update state {success, forcible, fail}
-				# TYPE nginx_ingress_controller_nginx_process_cert_count gauge
-				nginx_ingress_controller_nginx_process_cert_count{controller_class="nginx",controller_namespace="default",controller_pod="pod",result="fail"} 0
-				nginx_ingress_controller_nginx_process_cert_count{controller_class="nginx",controller_namespace="default",controller_pod="pod",result="forcible"} 0
-				nginx_ingress_controller_nginx_process_cert_count{controller_class="nginx",controller_namespace="default",controller_pod="pod",result="success"} 0
-				# HELP nginx_ingress_controller_nginx_process_cert_overflow_total number of valid items removed forcibly when out of storage in the shared memory zone
-				# TYPE nginx_ingress_controller_nginx_process_cert_overflow_total counter
-				nginx_ingress_controller_nginx_process_cert_overflow_total{controller_class="nginx",controller_namespace="default",controller_pod="pod"} 0
-				# HELP nginx_ingress_controller_nginx_process_dictionary_capacity capacity in bytes for the shm-based dictionary
-				# TYPE nginx_ingress_controller_nginx_process_dictionary_capacity gauge
-				nginx_ingress_controller_nginx_process_dictionary_capacity{controller_class="nginx",controller_namespace="default",controller_pod="pod",name="certificate"} 0
-				nginx_ingress_controller_nginx_process_dictionary_capacity{controller_class="nginx",controller_namespace="default",controller_pod="pod",name="configuration"} 0
-				# HELP nginx_ingress_controller_nginx_process_dictionary_free free page size in bytes for the shm-based dictionary
-				# TYPE nginx_ingress_controller_nginx_process_dictionary_free gauge
-				nginx_ingress_controller_nginx_process_dictionary_free{controller_class="nginx",controller_namespace="default",controller_pod="pod",name="certificate"} 0
-				nginx_ingress_controller_nginx_process_dictionary_free{controller_class="nginx",controller_namespace="default",controller_pod="pod",name="configuration"} 0			`,
+			`,
 			metrics: []string{
 				"nginx_ingress_controller_nginx_process_dictionary_capacity",
 				"nginx_ingress_controller_nginx_process_dictionary_free",
+				"nginx_ingress_controller_nginx_process_cert_bytes",
 				"nginx_ingress_controller_nginx_process_cert_count",
 				"nginx_ingress_controller_nginx_process_cert_overflow_total",
 			},
@@ -75,6 +61,7 @@ func TestLuaStatusCollector(t *testing.T) {
 			cert_last_fail: 6
 			cert_last_forcible: 7
 			cert_overflow_total: 8
+			cert_capacity_bytes: 9
 					  `,
 			want: `
 				# HELP nginx_ingress_controller_nginx_process_cert_count number of certs in last configuration update state {success, forcible, fail}
@@ -96,6 +83,7 @@ func TestLuaStatusCollector(t *testing.T) {
 			metrics: []string{
 				"nginx_ingress_controller_nginx_process_dictionary_capacity",
 				"nginx_ingress_controller_nginx_process_dictionary_free",
+				"nginx_ingress_controller_nginx_process_cert_bytes",
 				"nginx_ingress_controller_nginx_process_cert_count",
 				"nginx_ingress_controller_nginx_process_cert_overflow_total",
 			},

--- a/internal/ingress/metric/collectors/nginx_lua_status_test.go
+++ b/internal/ingress/metric/collectors/nginx_lua_status_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/ingress-nginx/internal/nginx"
+)
+
+func TestLuaStatusCollector(t *testing.T) {
+	cases := []struct {
+		name    string
+		mock    string
+		metrics []string
+		want    string
+	}{
+		{
+			name: "should return empty zero metrics",
+			mock: `
+			`,
+			want: `
+				# HELP nginx_ingress_controller_nginx_process_cert_count number of certs in last configuration update state {success, forcible, fail}
+				# TYPE nginx_ingress_controller_nginx_process_cert_count gauge
+				nginx_ingress_controller_nginx_process_cert_count{controller_class="nginx",controller_namespace="default",controller_pod="pod",result="fail"} 0
+				nginx_ingress_controller_nginx_process_cert_count{controller_class="nginx",controller_namespace="default",controller_pod="pod",result="forcible"} 0
+				nginx_ingress_controller_nginx_process_cert_count{controller_class="nginx",controller_namespace="default",controller_pod="pod",result="success"} 0
+				# HELP nginx_ingress_controller_nginx_process_cert_overflow_total number of valid items removed forcibly when out of storage in the shared memory zone
+				# TYPE nginx_ingress_controller_nginx_process_cert_overflow_total counter
+				nginx_ingress_controller_nginx_process_cert_overflow_total{controller_class="nginx",controller_namespace="default",controller_pod="pod"} 0
+				# HELP nginx_ingress_controller_nginx_process_dictionary_capacity capacity in bytes for the shm-based dictionary
+				# TYPE nginx_ingress_controller_nginx_process_dictionary_capacity gauge
+				nginx_ingress_controller_nginx_process_dictionary_capacity{controller_class="nginx",controller_namespace="default",controller_pod="pod",name="certificate"} 0
+				nginx_ingress_controller_nginx_process_dictionary_capacity{controller_class="nginx",controller_namespace="default",controller_pod="pod",name="configuration"} 0
+				# HELP nginx_ingress_controller_nginx_process_dictionary_free free page size in bytes for the shm-based dictionary
+				# TYPE nginx_ingress_controller_nginx_process_dictionary_free gauge
+				nginx_ingress_controller_nginx_process_dictionary_free{controller_class="nginx",controller_namespace="default",controller_pod="pod",name="certificate"} 0
+				nginx_ingress_controller_nginx_process_dictionary_free{controller_class="nginx",controller_namespace="default",controller_pod="pod",name="configuration"} 0			`,
+			metrics: []string{
+				"nginx_ingress_controller_nginx_process_dictionary_capacity",
+				"nginx_ingress_controller_nginx_process_dictionary_free",
+				"nginx_ingress_controller_nginx_process_cert_count",
+				"nginx_ingress_controller_nginx_process_cert_overflow_total",
+			},
+		},
+		{
+			name: "should return all metrics",
+			mock: `
+			conf_free_space_bytes: 1
+			conf_capacity_bytes: 2
+			cert_free_space_bytes: 3
+			cert_capacity_bytes: 4
+			cert_last_success: 5
+			cert_last_fail: 6
+			cert_last_forcible: 7
+			cert_overflow_total: 8
+					  `,
+			want: `
+				# HELP nginx_ingress_controller_nginx_process_cert_count number of certs in last configuration update state {success, forcible, fail}
+				# TYPE nginx_ingress_controller_nginx_process_cert_count gauge
+				nginx_ingress_controller_nginx_process_cert_count{controller_class="nginx",controller_namespace="default",controller_pod="pod",result="fail"} 6
+				nginx_ingress_controller_nginx_process_cert_count{controller_class="nginx",controller_namespace="default",controller_pod="pod",result="forcible"} 7
+				nginx_ingress_controller_nginx_process_cert_count{controller_class="nginx",controller_namespace="default",controller_pod="pod",result="success"} 5
+				# HELP nginx_ingress_controller_nginx_process_cert_overflow_total number of valid items removed forcibly when out of storage in the shared memory zone
+				# TYPE nginx_ingress_controller_nginx_process_cert_overflow_total counter
+				nginx_ingress_controller_nginx_process_cert_overflow_total{controller_class="nginx",controller_namespace="default",controller_pod="pod"} 8
+				# HELP nginx_ingress_controller_nginx_process_dictionary_capacity capacity in bytes for the shm-based dictionary
+				# TYPE nginx_ingress_controller_nginx_process_dictionary_capacity gauge
+				nginx_ingress_controller_nginx_process_dictionary_capacity{controller_class="nginx",controller_namespace="default",controller_pod="pod",name="certificate"} 4
+				nginx_ingress_controller_nginx_process_dictionary_capacity{controller_class="nginx",controller_namespace="default",controller_pod="pod",name="configuration"} 2
+				# HELP nginx_ingress_controller_nginx_process_dictionary_free free page size in bytes for the shm-based dictionary
+				# TYPE nginx_ingress_controller_nginx_process_dictionary_free gauge
+				nginx_ingress_controller_nginx_process_dictionary_free{controller_class="nginx",controller_namespace="default",controller_pod="pod",name="certificate"} 3
+				nginx_ingress_controller_nginx_process_dictionary_free{controller_class="nginx",controller_namespace="default",controller_pod="pod",name="configuration"} 1			`,
+			metrics: []string{
+				"nginx_ingress_controller_nginx_process_dictionary_capacity",
+				"nginx_ingress_controller_nginx_process_dictionary_free",
+				"nginx_ingress_controller_nginx_process_cert_count",
+				"nginx_ingress_controller_nginx_process_cert_overflow_total",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			listener, err := net.Listen("unix", nginx.StatusSocket)
+			if err != nil {
+				t.Fatalf("creating unix listener: %s", err)
+			}
+
+			server := &httptest.Server{
+				Listener: listener,
+				Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+
+					if r.URL.Path == "/configuration/metrics" {
+						_, err := fmt.Fprintf(w, c.mock)
+						if err != nil {
+							t.Fatal(err)
+						}
+
+						return
+					}
+
+					fmt.Fprintf(w, "OK")
+				})},
+			}
+			server.Start()
+
+			time.Sleep(1 * time.Second)
+
+			cm, err := NewNGINXLuaStatus("pod", "default", "nginx")
+			if err != nil {
+				t.Errorf("unexpected error creating nginx status collector: %v", err)
+			}
+
+			go cm.Start()
+
+			reg := prometheus.NewPedanticRegistry()
+			if err := reg.Register(cm); err != nil {
+				t.Errorf("registering collector failed: %s", err)
+			}
+
+			if err := GatherAndCompare(cm, c.want, c.metrics, reg); err != nil {
+				t.Errorf("unexpected collecting result:\n%s", err)
+			}
+
+			reg.Unregister(cm)
+
+			server.Close()
+			cm.Stop()
+
+			listener.Close()
+			os.Remove(nginx.StatusSocket)
+		})
+	}
+}

--- a/internal/nginx/main.go
+++ b/internal/nginx/main.go
@@ -47,6 +47,9 @@ var HealthCheckTimeout = 10 * time.Second
 // http://nginx.org/en/docs/http/ngx_http_stub_status_module.html
 var StatusPath = "/nginx_status"
 
+// LuaStatusPath defines the path used to expose the NGINX LUA status page
+var LuaStatusPath = "/configuration/metrics"
+
 // StreamSocket defines the location of the unix socket used by NGINX for the NGINX stream configuration socket
 var StreamSocket = "/tmp/ingress-stream.sock"
 

--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -3,6 +3,7 @@ local cjson = require("cjson.safe")
 -- this is the Lua representation of Configuration struct in internal/ingress/types.go
 local configuration_data = ngx.shared.configuration_data
 local certificate_data = ngx.shared.certificate_data
+local metrics_data = ngx.shared.metrics_data
 
 local _M = {}
 
@@ -55,14 +56,20 @@ local function handle_servers()
   end
 
   local err_buf = {}
+  local cert_count_success, cert_count_fail, cert_count_forcible = 0, 0, 0
   for _, server in ipairs(servers) do
     if server.hostname and server.sslCert.pemCertKey then
       local success, set_err, forcible = certificate_data:set(server.hostname, server.sslCert.pemCertKey)
       if not success then
         local err_msg = string.format("error setting certificate for %s: %s\n", server.hostname, tostring(set_err))
         table.insert(err_buf, err_msg)
+        cert_count_fail = cert_count_fail + 1
+      else
+        cert_count_success = cert_count_success + 1
       end
       if forcible then
+        cert_count_forcible = cert_count_forcible + 1
+        metrics_data:incr("cert_overflow_total", 1, 0, 0)
         local msg = string.format("certificate_data dictionary is full, LRU entry has been removed to store %s",
           server.hostname)
         ngx.log(ngx.WARN, msg)
@@ -71,6 +78,9 @@ local function handle_servers()
       ngx.log(ngx.WARN, "hostname or pemCertKey are not present")
     end
   end
+  metrics_data:set("cert_last_success", cert_count_success - cert_count_forcible)
+  metrics_data:set("cert_last_fail", cert_count_fail)
+  metrics_data:set("cert_last_forcible", cert_count_forcible)
 
   if #err_buf > 0 then
     ngx.log(ngx.ERR, table.concat(err_buf))
@@ -132,6 +142,18 @@ local function handle_certs()
   end
 end
 
+local function handle_metrics()
+  ngx.status = ngx.HTTP_OK
+  ngx.say("conf_free_space_bytes: ", configuration_data:free_space())
+  ngx.say("conf_capacity_bytes: ", configuration_data:capacity())
+  ngx.say("cert_free_space_bytes: ", certificate_data:free_space())
+  ngx.say("cert_capacity_bytes: ", certificate_data:capacity())
+  ngx.say("cert_last_success: ", metrics_data:get("cert_last_success") or 0)
+  ngx.say("cert_last_fail: ", metrics_data:get("cert_last_fail") or 0)
+  ngx.say("cert_last_forcible: ", metrics_data:get("cert_last_forcible") or 0)
+  ngx.say("cert_overflow_total: ", metrics_data:get("cert_overflow_total") or 0)
+end
+
 function _M.call()
   if ngx.var.request_method ~= "POST" and ngx.var.request_method ~= "GET" then
     ngx.status = ngx.HTTP_BAD_REQUEST
@@ -151,6 +173,11 @@ function _M.call()
 
   if ngx.var.uri == "/configuration/certs" then
     handle_certs()
+    return
+  end
+
+  if ngx.var.request_uri == "/configuration/metrics" then
+    handle_metrics()
     return
   end
 

--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -48,6 +48,10 @@ local function handle_servers()
 
   local raw_servers = fetch_request_body()
 
+  if raw_servers then
+    metrics_data:set("cert_last_bytes",  string.len(raw_servers))
+  end
+
   local servers, err = cjson.decode(raw_servers)
   if not servers then
     ngx.log(ngx.ERR, "could not parse servers: ", err)
@@ -152,6 +156,7 @@ local function handle_metrics()
   ngx.say("cert_last_fail: ", metrics_data:get("cert_last_fail") or 0)
   ngx.say("cert_last_forcible: ", metrics_data:get("cert_last_forcible") or 0)
   ngx.say("cert_overflow_total: ", metrics_data:get("cert_overflow_total") or 0)
+  ngx.say("cert_last_bytes: ", metrics_data:get("cert_last_bytes") or 0)
 end
 
 function _M.call()


### PR DESCRIPTION
**What this PR does / why we need it**:

Expose LUA configuration & certificate dictionary metrics to allow monitoring of approaching certification/configuration size limits.

**Special notes for your reviewer**:
New nginx_lua_status(_test).go files were forked from nginx_status(_test).go for approach.