### PR TITLE
Use an environment variable for the certificate shared dict size

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -133,7 +133,7 @@ var (
 			}
 			return true
 		},
-		"reduceByAlias":			  reduceByAlias,
+		"reduceByAlias":              reduceByAlias,
 		"escapeLiteralDollar":        escapeLiteralDollar,
 		"shouldConfigureLuaRestyWAF": shouldConfigureLuaRestyWAF,
 		"buildLuaSharedDictionaries": buildLuaSharedDictionaries,


### PR DESCRIPTION
**What this PR does / why we need it**:
Pulling the dict size from the config map causes the certificate dictionary to be resized, but not reloaded, causing the default cert to be served instead. Tying the dict size to the daemonset forces a pod restart when the size changes, which reloads the cert dict on pod startup.
